### PR TITLE
converting home page to core view with containers

### DIFF
--- a/actio/actio.xcodeproj/project.pbxproj
+++ b/actio/actio.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		724925EE20A8A19300137F15 /* SaveActivityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724925ED20A8A19300137F15 /* SaveActivityViewController.swift */; };
 		724BB47E20A7CDEE004A6724 /* ActivityStatsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724BB47D20A7CDEE004A6724 /* ActivityStatsViewController.swift */; };
 		724BB48020A7CE6E004A6724 /* InitialMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724BB47F20A7CE6E004A6724 /* InitialMapViewController.swift */; };
+		7254172E20AEA3C6009289B3 /* CoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7254172D20AEA3C6009289B3 /* CoreViewController.swift */; };
 		72573699209BFE9100E442BB /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 72573698209BFE9100E442BB /* GoogleService-Info.plist */; };
 		72EF6B26208BF410007CD9CD /* Yantramanav-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 72EF6B20208BF410007CD9CD /* Yantramanav-Bold.ttf */; };
 		72EF6B27208BF410007CD9CD /* Yantramanav-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 72EF6B21208BF410007CD9CD /* Yantramanav-Light.ttf */; };
@@ -84,6 +85,7 @@
 		724925ED20A8A19300137F15 /* SaveActivityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveActivityViewController.swift; sourceTree = "<group>"; };
 		724BB47D20A7CDEE004A6724 /* ActivityStatsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStatsViewController.swift; sourceTree = "<group>"; };
 		724BB47F20A7CE6E004A6724 /* InitialMapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialMapViewController.swift; sourceTree = "<group>"; };
+		7254172D20AEA3C6009289B3 /* CoreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreViewController.swift; sourceTree = "<group>"; };
 		72573698209BFE9100E442BB /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		72EF6B20208BF410007CD9CD /* Yantramanav-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Yantramanav-Bold.ttf"; sourceTree = "<group>"; };
 		72EF6B21208BF410007CD9CD /* Yantramanav-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Yantramanav-Light.ttf"; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				724BB47D20A7CDEE004A6724 /* ActivityStatsViewController.swift */,
 				31594F41209935E300F807D9 /* StartActivityViewController.swift */,
 				724925E920A80D3D00137F15 /* MainActivityViewController.swift */,
+				7254172D20AEA3C6009289B3 /* CoreViewController.swift */,
 				724925EB20A8A18200137F15 /* StatsActivityViewController.swift */,
 				724925ED20A8A19300137F15 /* SaveActivityViewController.swift */,
 			);
@@ -489,6 +492,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				72EF6B5120969A18007CD9CD /* ForgotPasswordViewController.swift in Sources */,
+				7254172E20AEA3C6009289B3 /* CoreViewController.swift in Sources */,
 				724925EE20A8A19300137F15 /* SaveActivityViewController.swift in Sources */,
 				72365EF52086E13900413444 /* ViewController.swift in Sources */,
 				31594F402098B53B00F807D9 /* Loc.swift in Sources */,

--- a/actio/actio/Base.lproj/Main.storyboard
+++ b/actio/actio/Base.lproj/Main.storyboard
@@ -516,7 +516,11 @@
                             <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="K7R-Pq-Yi2">
                                 <rect key="frame" x="0.0" y="518" width="414" height="44"/>
                                 <items>
-                                    <barButtonItem title="Item" image="ic_home" id="7d6-Fd-D4k"/>
+                                    <barButtonItem title="Item" image="ic_home" id="7d6-Fd-D4k">
+                                        <connections>
+                                            <action selector="showActivityCollectionViewWithSender:" destination="Iye-nz-8E5" id="ZCJ-Xo-AE2"/>
+                                        </connections>
+                                    </barButtonItem>
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="g6e-om-eMF"/>
                                     <barButtonItem title="Item" image="ic_fiber_smart_record" width="76" id="LFe-Nm-ETk">
                                         <connections>
@@ -534,11 +538,14 @@
                                     <navigationItem title="My Activities" id="1X8-OW-TSM">
                                         <barButtonItem key="leftBarButtonItem" title="Settings" image="ic_add_circle" id="9Ex-UX-LIh">
                                             <color key="tintColor" red="1" green="0.87058823529999996" blue="0.55294117649999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <connections>
+                                                <action selector="showManualAddViewWithSender:" destination="Iye-nz-8E5" id="LUf-MK-H5B"/>
+                                            </connections>
                                         </barButtonItem>
                                         <barButtonItem key="rightBarButtonItem" title="Close" image="ic_perm_identity" id="MlE-1V-0S5">
                                             <color key="tintColor" red="1" green="0.87058823529999996" blue="0.55294117649999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <connections>
-                                                <action selector="closeButtonPressed:" destination="Uq0-XJ-M4B" id="0Wb-u6-kpq"/>
+                                                <action selector="showProfileViewWithSender:" destination="Iye-nz-8E5" id="QNi-kq-PYd"/>
                                             </connections>
                                         </barButtonItem>
                                     </navigationItem>
@@ -665,7 +672,10 @@
                     <connections>
                         <outlet property="activityCollectionContainerView" destination="u8K-at-Gkx" id="482-g6-RVe"/>
                         <outlet property="chooseView" destination="GUc-7x-7jJ" id="X5A-PB-K7O"/>
+                        <outlet property="homeButton" destination="7d6-Fd-D4k" id="KxC-pr-9Ru"/>
+                        <outlet property="manualAddButton" destination="9Ex-UX-LIh" id="F6A-Bl-lvv"/>
                         <outlet property="manualAddContainerView" destination="iJY-UW-Grx" id="eAU-b2-T50"/>
+                        <outlet property="profileButton" destination="7d6-Fd-D4k" id="DjL-J8-TUS"/>
                         <outlet property="profileContainerView" destination="qk5-cx-u5k" id="vK8-t1-jZO"/>
                     </connections>
                 </viewController>

--- a/actio/actio/Base.lproj/Main.storyboard
+++ b/actio/actio/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="tE0-sv-0ak">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Iye-nz-8E5">
     <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -181,7 +181,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-276" y="-1172"/>
+            <point key="canvasLocation" x="-546" y="-1085"/>
         </scene>
         <!--SignInViewController-->
         <scene sceneID="8uU-yY-YWg">
@@ -291,7 +291,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Y8k-hf-dLF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="98" y="-31"/>
+            <point key="canvasLocation" x="1359" y="-1085"/>
         </scene>
         <!--SignUpViewController-->
         <scene sceneID="AoH-SC-Oul">
@@ -413,7 +413,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6rO-O5-2uI" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="NAU-3d-Qpo" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="-893" y="-32"/>
+            <point key="canvasLocation" x="519" y="-1085"/>
         </scene>
         <!--ForgotPasswordViewController-->
         <scene sceneID="vNW-oV-1lm">
@@ -503,264 +503,32 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dxH-hQ-PnM" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1022" y="-32"/>
+            <point key="canvasLocation" x="2223" y="-1085"/>
         </scene>
-        <!--MainController-->
-        <scene sceneID="z8E-vl-8uC">
+        <!--MainView-->
+        <scene sceneID="ZDI-WO-zKh">
             <objects>
-                <viewController storyboardIdentifier="MainView" title="MainController" id="tE0-sv-0ak" customClass="ActivityCollectionViewController" customModule="actio" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="egi-g7-dBq">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                <viewController storyboardIdentifier="MainView" title="MainView" id="Iye-nz-8E5" customClass="CoreViewController" customModule="actio" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Mg0-qu-2Pq">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="562"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView verifyAmbiguity="off" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsVerticalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kei-uO-JMH">
-                                <rect key="frame" x="0.0" y="64" width="414" height="628"/>
-                                <subviews>
-                                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="FW6-pe-utx">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="628"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="4" id="g5W-gu-sBp">
-                                            <size key="itemSize" width="360" height="200"/>
-                                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                        </collectionViewFlowLayout>
-                                        <cells>
-                                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="sectionCell" id="9mo-pd-nhU">
-                                                <rect key="frame" x="7" y="0.0" width="400" height="200"/>
-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
-                                                    <rect key="frame" x="0.0" y="0.0" width="400" height="200"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <subviews>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cFo-I9-NWU">
-                                                            <rect key="frame" x="8" y="8" width="384" height="184"/>
-                                                            <subviews>
-                                                                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NqI-yd-ai5">
-                                                                    <rect key="frame" x="4" y="0.0" width="380" height="184"/>
-                                                                    <subviews>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hYR-WU-gvy">
-                                                                            <rect key="frame" x="12" y="12" width="167" height="23"/>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="swquare_map" translatesAutoresizingMaskIntoConstraints="NO" id="1Mk-nE-wn6">
-                                                                            <rect key="frame" x="187" y="0.0" width="193" height="184"/>
-                                                                        </imageView>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="April 12, 2018" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iMm-kk-Z7c">
-                                                                            <rect key="frame" x="12" y="34" width="167" height="23"/>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3.31" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cRC-5I-PJJ">
-                                                                            <rect key="frame" x="12" y="66" width="71" height="23"/>
-                                                                            <constraints>
-                                                                                <constraint firstAttribute="height" constant="23" id="RfZ-4Q-EHU"/>
-                                                                            </constraints>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="distance" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="INa-iy-P2z">
-                                                                            <rect key="frame" x="12" y="87" width="71" height="23"/>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
-                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10.02" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vt3-Dz-QGM">
-                                                                            <rect key="frame" x="91" y="65" width="71" height="23"/>
-                                                                            <constraints>
-                                                                                <constraint firstAttribute="width" constant="71" id="862-di-Kwp"/>
-                                                                            </constraints>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="pace" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bVJ-Zl-eQl">
-                                                                            <rect key="frame" x="91" y="87" width="71" height="23"/>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
-                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="30:09" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4hh-SK-I6M">
-                                                                            <rect key="frame" x="91" y="110" width="71" height="23"/>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="duration" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iP5-Zx-aJc">
-                                                                            <rect key="frame" x="91" y="132" width="71" height="23"/>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
-                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                    </subviews>
-                                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                    <constraints>
-                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="leading" secondItem="bVJ-Zl-eQl" secondAttribute="leading" id="1dv-aV-Y41"/>
-                                                                        <constraint firstItem="iMm-kk-Z7c" firstAttribute="leading" secondItem="cRC-5I-PJJ" secondAttribute="leading" id="3JB-GM-5Ty"/>
-                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="trailing" secondItem="bVJ-Zl-eQl" secondAttribute="trailing" id="B93-DR-Qpz"/>
-                                                                        <constraint firstItem="bVJ-Zl-eQl" firstAttribute="leading" secondItem="4hh-SK-I6M" secondAttribute="leading" id="D54-dW-R6W"/>
-                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="leading" secondItem="cRC-5I-PJJ" secondAttribute="trailing" constant="8" symbolic="YES" id="DWc-Ca-whn"/>
-                                                                        <constraint firstItem="iP5-Zx-aJc" firstAttribute="top" secondItem="bVJ-Zl-eQl" secondAttribute="bottom" constant="22" id="DoW-ig-0w4"/>
-                                                                        <constraint firstItem="cRC-5I-PJJ" firstAttribute="leading" secondItem="INa-iy-P2z" secondAttribute="leading" id="EgR-56-7SB"/>
-                                                                        <constraint firstItem="hYR-WU-gvy" firstAttribute="leading" secondItem="iMm-kk-Z7c" secondAttribute="leading" id="FIH-GF-Eiy"/>
-                                                                        <constraint firstAttribute="bottom" secondItem="4hh-SK-I6M" secondAttribute="bottom" constant="51" id="GLo-OG-NdB"/>
-                                                                        <constraint firstItem="iMm-kk-Z7c" firstAttribute="top" secondItem="NqI-yd-ai5" secondAttribute="top" constant="34" id="HRd-fk-Sgl"/>
-                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="top" secondItem="hYR-WU-gvy" secondAttribute="bottom" constant="30" id="ImU-ye-510"/>
-                                                                        <constraint firstItem="INa-iy-P2z" firstAttribute="firstBaseline" secondItem="bVJ-Zl-eQl" secondAttribute="firstBaseline" id="Jmp-VL-UVU"/>
-                                                                        <constraint firstItem="4hh-SK-I6M" firstAttribute="top" secondItem="vt3-Dz-QGM" secondAttribute="bottom" constant="22" id="Jvo-aZ-BOt"/>
-                                                                        <constraint firstAttribute="bottom" secondItem="iP5-Zx-aJc" secondAttribute="bottom" constant="29" id="S4C-NW-OF0"/>
-                                                                        <constraint firstItem="bVJ-Zl-eQl" firstAttribute="trailing" secondItem="4hh-SK-I6M" secondAttribute="trailing" id="ZUK-3K-ROf"/>
-                                                                        <constraint firstItem="1Mk-nE-wn6" firstAttribute="leading" secondItem="iMm-kk-Z7c" secondAttribute="trailing" constant="8" symbolic="YES" id="aKM-Al-Dmc"/>
-                                                                        <constraint firstItem="1Mk-nE-wn6" firstAttribute="leading" secondItem="vt3-Dz-QGM" secondAttribute="trailing" constant="25" id="bN4-Li-BjD"/>
-                                                                        <constraint firstItem="hYR-WU-gvy" firstAttribute="leading" secondItem="NqI-yd-ai5" secondAttribute="leading" constant="12" id="baH-fW-BNJ"/>
-                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="top" secondItem="iMm-kk-Z7c" secondAttribute="bottom" constant="8" symbolic="YES" id="btw-Tv-4VS"/>
-                                                                        <constraint firstItem="INa-iy-P2z" firstAttribute="baseline" secondItem="bVJ-Zl-eQl" secondAttribute="baseline" id="e3p-gr-sj6"/>
-                                                                        <constraint firstAttribute="bottom" secondItem="1Mk-nE-wn6" secondAttribute="bottom" id="lFG-wQ-CaN"/>
-                                                                        <constraint firstItem="1Mk-nE-wn6" firstAttribute="top" secondItem="NqI-yd-ai5" secondAttribute="top" id="lM1-TB-f1I"/>
-                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="leading" secondItem="INa-iy-P2z" secondAttribute="trailing" constant="8" symbolic="YES" id="m0F-Fh-wFx"/>
-                                                                        <constraint firstItem="4hh-SK-I6M" firstAttribute="leading" secondItem="iP5-Zx-aJc" secondAttribute="leading" id="mIa-gH-eca"/>
-                                                                        <constraint firstItem="4hh-SK-I6M" firstAttribute="top" secondItem="bVJ-Zl-eQl" secondAttribute="bottom" id="ngH-EA-OGj"/>
-                                                                        <constraint firstAttribute="bottom" secondItem="cRC-5I-PJJ" secondAttribute="bottom" constant="95" id="ngW-e0-c3M"/>
-                                                                        <constraint firstAttribute="bottom" secondItem="INa-iy-P2z" secondAttribute="bottom" constant="74" id="paT-fa-XR0"/>
-                                                                        <constraint firstItem="hYR-WU-gvy" firstAttribute="top" secondItem="NqI-yd-ai5" secondAttribute="top" constant="12" id="rPo-vf-NRX"/>
-                                                                        <constraint firstItem="1Mk-nE-wn6" firstAttribute="leading" secondItem="hYR-WU-gvy" secondAttribute="trailing" constant="8" symbolic="YES" id="sC8-Za-PzM"/>
-                                                                        <constraint firstItem="INa-iy-P2z" firstAttribute="top" secondItem="iMm-kk-Z7c" secondAttribute="bottom" constant="30" id="umV-yy-6pa"/>
-                                                                        <constraint firstItem="4hh-SK-I6M" firstAttribute="trailing" secondItem="iP5-Zx-aJc" secondAttribute="trailing" id="uqZ-ev-8SI"/>
-                                                                        <constraint firstAttribute="trailing" secondItem="1Mk-nE-wn6" secondAttribute="trailing" id="wOq-d2-bj9"/>
-                                                                        <constraint firstItem="cRC-5I-PJJ" firstAttribute="top" secondItem="iMm-kk-Z7c" secondAttribute="bottom" constant="9" id="y1C-rU-fi9"/>
-                                                                        <constraint firstItem="4hh-SK-I6M" firstAttribute="leading" secondItem="NqI-yd-ai5" secondAttribute="leading" constant="91" id="yUM-bs-wVJ"/>
-                                                                    </constraints>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                            <integer key="value" value="2"/>
-                                                                        </userDefinedRuntimeAttribute>
-                                                                    </userDefinedRuntimeAttributes>
-                                                                </view>
-                                                            </subviews>
-                                                            <color key="backgroundColor" red="0.58823529409999997" green="1" blue="0.86274509799999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="bottom" secondItem="NqI-yd-ai5" secondAttribute="bottom" id="86k-vt-83z"/>
-                                                                <constraint firstItem="NqI-yd-ai5" firstAttribute="leading" secondItem="cFo-I9-NWU" secondAttribute="leading" constant="4" id="E9u-gg-P1d"/>
-                                                                <constraint firstAttribute="trailing" secondItem="NqI-yd-ai5" secondAttribute="trailing" id="OdE-ef-cAA"/>
-                                                                <constraint firstItem="NqI-yd-ai5" firstAttribute="top" secondItem="cFo-I9-NWU" secondAttribute="top" id="sO6-8m-0Pw"/>
-                                                            </constraints>
-                                                            <userDefinedRuntimeAttributes>
-                                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
-                                                                    <real key="value" value="0.25"/>
-                                                                </userDefinedRuntimeAttribute>
-                                                                <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
-                                                                    <size key="value" width="1" height="1"/>
-                                                                </userDefinedRuntimeAttribute>
-                                                            </userDefinedRuntimeAttributes>
-                                                        </view>
-                                                    </subviews>
-                                                </view>
-                                                <constraints>
-                                                    <constraint firstAttribute="bottomMargin" secondItem="cFo-I9-NWU" secondAttribute="bottom" id="0bz-d0-gGc"/>
-                                                    <constraint firstItem="cFo-I9-NWU" firstAttribute="top" secondItem="9mo-pd-nhU" secondAttribute="topMargin" id="A7Q-fa-EZ5"/>
-                                                    <constraint firstAttribute="trailingMargin" secondItem="cFo-I9-NWU" secondAttribute="trailing" id="GHt-Dj-q3V"/>
-                                                    <constraint firstItem="cFo-I9-NWU" firstAttribute="leading" secondItem="9mo-pd-nhU" secondAttribute="leadingMargin" id="O9b-qw-BTk"/>
-                                                </constraints>
-                                                <size key="customSize" width="400" height="200"/>
-                                            </collectionViewCell>
-                                        </cells>
-                                    </collectionView>
-                                    <view opaque="NO" contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="GUc-7x-7jJ">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="628"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="cDC-SH-Bam">
-                                                <rect key="frame" x="87" y="145" width="240" height="339"/>
-                                                <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KKQ-ZK-Asr">
-                                                        <rect key="frame" x="0.0" y="0.0" width="240" height="113"/>
-                                                        <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select an activity type" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZQe-aR-SVC">
-                                                                <rect key="frame" x="0.0" y="0.0" width="240" height="113"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                <color key="textColor" red="0.98253947496414185" green="0.99252063035964966" blue="0.99219316244125366" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                        </subviews>
-                                                        <color key="backgroundColor" red="0.68627450980000004" green="0.0" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="bottom" secondItem="ZQe-aR-SVC" secondAttribute="bottom" id="S1r-wD-G1V"/>
-                                                            <constraint firstAttribute="trailing" secondItem="ZQe-aR-SVC" secondAttribute="trailing" id="Tud-cB-yFJ"/>
-                                                            <constraint firstItem="ZQe-aR-SVC" firstAttribute="leading" secondItem="KKQ-ZK-Asr" secondAttribute="leading" id="lFh-b5-H09"/>
-                                                            <constraint firstItem="ZQe-aR-SVC" firstAttribute="top" secondItem="KKQ-ZK-Asr" secondAttribute="top" id="ptL-EP-6e4"/>
-                                                        </constraints>
-                                                    </view>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yg5-iI-ebE">
-                                                        <rect key="frame" x="0.0" y="113" width="240" height="113"/>
-                                                        <color key="backgroundColor" red="0.98253947496414185" green="0.99252063035964966" blue="0.99219316244125366" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <fontDescription key="fontDescription" name="Yantramanav-Light" family="Yantramanav" pointSize="26"/>
-                                                        <inset key="titleEdgeInsets" minX="24" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="24" maxY="0.0"/>
-                                                        <state key="normal" title="Run" image="ic_directions_run">
-                                                            <color key="titleColor" red="0.68627450980000004" green="0.0" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                            <color key="titleShadowColor" red="0.68627450980000004" green="0.0" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="didPressRun" destination="tE0-sv-0ak" eventType="touchDown" id="TEI-Aa-SxO"/>
-                                                            <segue destination="Uq0-XJ-M4B" kind="presentation" identifier="activitySegue" id="eCp-ZK-pTW"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xi4-0o-9CZ">
-                                                        <rect key="frame" x="0.0" y="226" width="240" height="113"/>
-                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <fontDescription key="fontDescription" name="Yantramanav-Light" family="Yantramanav" pointSize="26"/>
-                                                        <inset key="titleEdgeInsets" minX="24" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="24" maxY="0.0"/>
-                                                        <state key="normal" title="Bike" image="ic_directions_bike">
-                                                            <color key="titleColor" red="0.68627450980000004" green="0.0" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="didPressBike" destination="tE0-sv-0ak" eventType="touchDown" id="baq-aL-Gdd"/>
-                                                            <segue destination="Uq0-XJ-M4B" kind="presentation" identifier="activitySegue" id="B8J-EK-AmQ"/>
-                                                        </connections>
-                                                    </button>
-                                                </subviews>
-                                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </stackView>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstItem="cDC-SH-Bam" firstAttribute="centerX" secondItem="GUc-7x-7jJ" secondAttribute="centerX" id="7Me-Q4-BsO"/>
-                                            <constraint firstItem="cDC-SH-Bam" firstAttribute="centerY" secondItem="GUc-7x-7jJ" secondAttribute="centerY" id="Bue-Ni-lyT"/>
-                                            <constraint firstItem="cDC-SH-Bam" firstAttribute="top" secondItem="GUc-7x-7jJ" secondAttribute="top" constant="145" id="Ev3-1k-x1H"/>
-                                            <constraint firstItem="cDC-SH-Bam" firstAttribute="leading" secondItem="GUc-7x-7jJ" secondAttribute="leading" constant="87" id="rPJ-7n-oOC"/>
-                                        </constraints>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.dropShadow">
-                                                <integer key="value" value="5"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
-                                                <real key="value" value="0.5"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
-                                    </view>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstItem="FW6-pe-utx" firstAttribute="bottom" secondItem="4Y8-s9-vFK" secondAttribute="bottom" id="2Ol-F7-RmT"/>
-                                    <constraint firstItem="FW6-pe-utx" firstAttribute="trailing" secondItem="GUc-7x-7jJ" secondAttribute="trailing" id="9nn-dy-hGr"/>
-                                    <constraint firstItem="FW6-pe-utx" firstAttribute="top" secondItem="4Y8-s9-vFK" secondAttribute="top" id="Cce-bF-Gt0"/>
-                                    <constraint firstAttribute="bottom" secondItem="FW6-pe-utx" secondAttribute="bottom" id="HvN-dc-8q5"/>
-                                    <constraint firstAttribute="trailing" secondItem="FW6-pe-utx" secondAttribute="trailing" id="KKh-OG-cpx"/>
-                                    <constraint firstItem="GUc-7x-7jJ" firstAttribute="trailing" secondItem="4Y8-s9-vFK" secondAttribute="trailing" id="Nze-es-9Xs"/>
-                                    <constraint firstItem="GUc-7x-7jJ" firstAttribute="bottom" secondItem="4Y8-s9-vFK" secondAttribute="bottom" id="O0X-xQ-mnN"/>
-                                    <constraint firstItem="FW6-pe-utx" firstAttribute="leading" secondItem="GUc-7x-7jJ" secondAttribute="leading" id="Vl6-79-G1l"/>
-                                    <constraint firstItem="FW6-pe-utx" firstAttribute="top" secondItem="GUc-7x-7jJ" secondAttribute="top" id="bqH-Xa-lY6"/>
-                                    <constraint firstItem="GUc-7x-7jJ" firstAttribute="leading" secondItem="4Y8-s9-vFK" secondAttribute="leading" id="hEV-lW-JgC"/>
-                                </constraints>
-                                <viewLayoutGuide key="safeArea" id="4Y8-s9-vFK"/>
-                            </scrollView>
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="K7R-Pq-Yi2">
+                                <rect key="frame" x="0.0" y="518" width="414" height="44"/>
+                                <items>
+                                    <barButtonItem title="Item" image="ic_home" id="7d6-Fd-D4k"/>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="g6e-om-eMF"/>
+                                    <barButtonItem title="Item" image="ic_fiber_smart_record" width="76" id="LFe-Nm-ETk">
+                                        <connections>
+                                            <action selector="showChooseView:" destination="Iye-nz-8E5" id="nqx-B4-dAJ"/>
+                                        </connections>
+                                    </barButtonItem>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="igb-6I-Vlu"/>
+                                    <barButtonItem title="Item" image="ic_more_horiz" id="3Jz-Cy-451"/>
+                                </items>
+                            </toolbar>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5nb-Gv-ZEd">
                                 <rect key="frame" x="0.0" y="20" width="414" height="44"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="rXH-wE-968"/>
-                                </constraints>
                                 <color key="barTintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <items>
                                     <navigationItem title="My Activities" id="1X8-OW-TSM">
@@ -776,80 +544,134 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
-                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="K7R-Pq-Yi2">
-                                <rect key="frame" x="0.0" y="648" width="414" height="44"/>
-                                <items>
-                                    <barButtonItem title="Item" image="ic_home" id="7d6-Fd-D4k"/>
-                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="g6e-om-eMF"/>
-                                    <barButtonItem title="Item" image="ic_fiber_smart_record" width="76" id="LFe-Nm-ETk">
-                                        <connections>
-                                            <action selector="showChooseView:" destination="tE0-sv-0ak" id="Y9V-mM-uJi"/>
-                                        </connections>
-                                    </barButtonItem>
-                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="igb-6I-Vlu"/>
-                                    <barButtonItem title="Item" image="ic_more_horiz" id="3Jz-Cy-451"/>
-                                </items>
-                            </toolbar>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u8K-at-Gkx">
+                                <rect key="frame" x="0.0" y="64" width="414" height="454"/>
+                                <connections>
+                                    <segue destination="A9m-Cb-1uW" kind="embed" id="LAb-Vp-8ni"/>
+                                </connections>
+                            </containerView>
+                            <containerView opaque="NO" alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iJY-UW-Grx">
+                                <rect key="frame" x="0.0" y="64" width="414" height="454"/>
+                                <connections>
+                                    <segue destination="9E8-DX-g5o" kind="embed" id="uaT-6f-o1S"/>
+                                </connections>
+                            </containerView>
+                            <containerView opaque="NO" alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qk5-cx-u5k">
+                                <rect key="frame" x="0.0" y="64" width="414" height="454"/>
+                                <connections>
+                                    <segue destination="IDP-0e-GQV" kind="embed" id="mS1-Zv-izL"/>
+                                </connections>
+                            </containerView>
+                            <view opaque="NO" contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="GUc-7x-7jJ">
+                                <rect key="frame" x="0.0" y="64" width="414" height="454"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="cDC-SH-Bam">
+                                        <rect key="frame" x="87" y="145" width="240" height="164"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KKQ-ZK-Asr">
+                                                <rect key="frame" x="0.0" y="0.0" width="240" height="54.666666666666664"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select an activity type" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZQe-aR-SVC">
+                                                        <rect key="frame" x="0.0" y="0.0" width="240" height="54.666666666666664"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <color key="textColor" red="0.98253947496414185" green="0.99252063035964966" blue="0.99219316244125366" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" red="0.68627450980000004" green="0.0" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="ZQe-aR-SVC" secondAttribute="bottom" id="S1r-wD-G1V"/>
+                                                    <constraint firstAttribute="trailing" secondItem="ZQe-aR-SVC" secondAttribute="trailing" id="Tud-cB-yFJ"/>
+                                                    <constraint firstItem="ZQe-aR-SVC" firstAttribute="leading" secondItem="KKQ-ZK-Asr" secondAttribute="leading" id="lFh-b5-H09"/>
+                                                    <constraint firstItem="ZQe-aR-SVC" firstAttribute="top" secondItem="KKQ-ZK-Asr" secondAttribute="top" id="ptL-EP-6e4"/>
+                                                </constraints>
+                                            </view>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yg5-iI-ebE">
+                                                <rect key="frame" x="0.0" y="54.666666666666686" width="240" height="54.666666666666657"/>
+                                                <color key="backgroundColor" red="0.98253947496414185" green="0.99252063035964966" blue="0.99219316244125366" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <fontDescription key="fontDescription" name="Yantramanav-Light" family="Yantramanav" pointSize="26"/>
+                                                <inset key="titleEdgeInsets" minX="24" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="24" maxY="0.0"/>
+                                                <state key="normal" title="Run" image="ic_directions_run">
+                                                    <color key="titleColor" red="0.68627450980000004" green="0.0" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                    <color key="titleShadowColor" red="0.68627450980000004" green="0.0" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="didPressRun" destination="Iye-nz-8E5" eventType="touchUpInside" id="4Wq-t5-9a4"/>
+                                                    <segue destination="Uq0-XJ-M4B" kind="presentation" identifier="activitySegue" id="eCp-ZK-pTW"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xi4-0o-9CZ">
+                                                <rect key="frame" x="0.0" y="109.33333333333333" width="240" height="54.666666666666671"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" name="Yantramanav-Light" family="Yantramanav" pointSize="26"/>
+                                                <inset key="titleEdgeInsets" minX="24" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="24" maxY="0.0"/>
+                                                <state key="normal" title="Bike" image="ic_directions_bike">
+                                                    <color key="titleColor" red="0.68627450980000004" green="0.0" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="didPressBike" destination="Iye-nz-8E5" eventType="touchUpInside" id="a3U-D9-oqc"/>
+                                                    <segue destination="Uq0-XJ-M4B" kind="presentation" identifier="activitySegue" id="B8J-EK-AmQ"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="cDC-SH-Bam" firstAttribute="centerX" secondItem="GUc-7x-7jJ" secondAttribute="centerX" id="7Me-Q4-BsO"/>
+                                    <constraint firstItem="cDC-SH-Bam" firstAttribute="centerY" secondItem="GUc-7x-7jJ" secondAttribute="centerY" id="Bue-Ni-lyT"/>
+                                    <constraint firstItem="cDC-SH-Bam" firstAttribute="top" secondItem="GUc-7x-7jJ" secondAttribute="top" constant="145" id="Ev3-1k-x1H"/>
+                                    <constraint firstItem="cDC-SH-Bam" firstAttribute="leading" secondItem="GUc-7x-7jJ" secondAttribute="leading" constant="87" id="rPJ-7n-oOC"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.dropShadow">
+                                        <integer key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
+                                        <real key="value" value="0.5"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <color key="tintColor" red="0.68627450980000004" green="0.0" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
-                            <constraint firstItem="XAc-yD-bcJ" firstAttribute="bottom" secondItem="K7R-Pq-Yi2" secondAttribute="bottom" id="0Go-si-gbC"/>
-                            <constraint firstItem="kei-uO-JMH" firstAttribute="bottom" secondItem="XAc-yD-bcJ" secondAttribute="bottom" id="2Oc-Id-3hH"/>
-                            <constraint firstItem="K7R-Pq-Yi2" firstAttribute="trailing" secondItem="XAc-yD-bcJ" secondAttribute="trailing" id="53R-10-xue"/>
-                            <constraint firstItem="5nb-Gv-ZEd" firstAttribute="top" secondItem="XAc-yD-bcJ" secondAttribute="top" id="9lE-15-KGp"/>
-                            <constraint firstItem="XAc-yD-bcJ" firstAttribute="bottom" secondItem="K7R-Pq-Yi2" secondAttribute="bottom" id="Big-0Y-vXg"/>
-                            <constraint firstItem="K7R-Pq-Yi2" firstAttribute="trailing" secondItem="XAc-yD-bcJ" secondAttribute="trailing" id="Fdl-YN-cyS"/>
-                            <constraint firstItem="K7R-Pq-Yi2" firstAttribute="leading" secondItem="XAc-yD-bcJ" secondAttribute="leading" id="FfK-BF-WPT"/>
-                            <constraint firstItem="kei-uO-JMH" firstAttribute="trailing" secondItem="XAc-yD-bcJ" secondAttribute="trailing" id="V5i-23-yba"/>
-                            <constraint firstItem="K7R-Pq-Yi2" firstAttribute="leading" secondItem="XAc-yD-bcJ" secondAttribute="leading" id="mLr-lQ-UOg"/>
-                            <constraint firstItem="kei-uO-JMH" firstAttribute="leading" secondItem="XAc-yD-bcJ" secondAttribute="leading" id="q93-f9-Tno"/>
-                            <constraint firstItem="kei-uO-JMH" firstAttribute="top" secondItem="5nb-Gv-ZEd" secondAttribute="bottom" id="sWB-6Q-QxU"/>
-                            <constraint firstItem="5nb-Gv-ZEd" firstAttribute="trailing" secondItem="XAc-yD-bcJ" secondAttribute="trailing" id="uob-HO-bcs"/>
-                            <constraint firstItem="5nb-Gv-ZEd" firstAttribute="leading" secondItem="XAc-yD-bcJ" secondAttribute="leading" id="wm7-bg-eoj"/>
+                            <constraint firstItem="GUc-7x-7jJ" firstAttribute="leading" secondItem="u8K-at-Gkx" secondAttribute="leading" id="4eI-YE-aHJ"/>
+                            <constraint firstItem="5nb-Gv-ZEd" firstAttribute="leading" secondItem="u8K-at-Gkx" secondAttribute="leading" id="5G3-2j-ZPr"/>
+                            <constraint firstItem="iJY-UW-Grx" firstAttribute="bottom" secondItem="K7R-Pq-Yi2" secondAttribute="top" id="6L3-ed-Qg0"/>
+                            <constraint firstItem="5nb-Gv-ZEd" firstAttribute="top" secondItem="TXm-78-GgK" secondAttribute="top" id="92X-h8-3yE"/>
+                            <constraint firstItem="iJY-UW-Grx" firstAttribute="leading" secondItem="qk5-cx-u5k" secondAttribute="leading" id="9Ba-xR-Kfu"/>
+                            <constraint firstItem="iJY-UW-Grx" firstAttribute="trailing" secondItem="u8K-at-Gkx" secondAttribute="trailing" id="BT1-mf-USm"/>
+                            <constraint firstAttribute="trailing" secondItem="u8K-at-Gkx" secondAttribute="trailing" id="Biy-ZF-Q3g"/>
+                            <constraint firstItem="qk5-cx-u5k" firstAttribute="trailing" secondItem="u8K-at-Gkx" secondAttribute="trailing" id="Jom-KS-KYe"/>
+                            <constraint firstAttribute="bottom" secondItem="u8K-at-Gkx" secondAttribute="bottom" constant="44" id="Kni-5g-bY1"/>
+                            <constraint firstItem="qk5-cx-u5k" firstAttribute="leading" secondItem="GUc-7x-7jJ" secondAttribute="leading" id="L6s-hB-jFe"/>
+                            <constraint firstItem="K7R-Pq-Yi2" firstAttribute="leading" secondItem="u8K-at-Gkx" secondAttribute="leading" id="MXN-Io-TNe"/>
+                            <constraint firstItem="GUc-7x-7jJ" firstAttribute="bottom" secondItem="K7R-Pq-Yi2" secondAttribute="top" id="N5v-Eg-CES"/>
+                            <constraint firstItem="u8K-at-Gkx" firstAttribute="top" secondItem="Mg0-qu-2Pq" secondAttribute="top" constant="64" id="SYB-Lq-KZc"/>
+                            <constraint firstItem="K7R-Pq-Yi2" firstAttribute="trailing" secondItem="u8K-at-Gkx" secondAttribute="trailing" id="Sd0-Nh-Q3G"/>
+                            <constraint firstItem="qk5-cx-u5k" firstAttribute="bottom" secondItem="K7R-Pq-Yi2" secondAttribute="top" id="XCR-P3-8Fd"/>
+                            <constraint firstItem="iJY-UW-Grx" firstAttribute="top" secondItem="u8K-at-Gkx" secondAttribute="top" id="YBX-h6-cpS"/>
+                            <constraint firstItem="K7R-Pq-Yi2" firstAttribute="top" secondItem="u8K-at-Gkx" secondAttribute="bottom" id="ZXW-QD-929"/>
+                            <constraint firstItem="qk5-cx-u5k" firstAttribute="top" secondItem="u8K-at-Gkx" secondAttribute="top" id="baZ-X9-oIF"/>
+                            <constraint firstItem="5nb-Gv-ZEd" firstAttribute="trailing" secondItem="u8K-at-Gkx" secondAttribute="trailing" id="hvu-3i-JZ2"/>
+                            <constraint firstItem="u8K-at-Gkx" firstAttribute="leading" secondItem="Mg0-qu-2Pq" secondAttribute="leading" id="jpT-4F-k3E"/>
+                            <constraint firstItem="GUc-7x-7jJ" firstAttribute="top" secondItem="u8K-at-Gkx" secondAttribute="top" id="pBs-yK-JYG"/>
+                            <constraint firstItem="GUc-7x-7jJ" firstAttribute="trailing" secondItem="u8K-at-Gkx" secondAttribute="trailing" id="rXA-up-5zq"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="XAc-yD-bcJ"/>
+                        <viewLayoutGuide key="safeArea" id="TXm-78-GgK"/>
                     </view>
-                    <toolbarItems/>
-                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="activityCollectionView" destination="FW6-pe-utx" id="6JQ-Zl-id4"/>
-                        <outlet property="chooseView" destination="GUc-7x-7jJ" id="17U-IE-vQo"/>
+                        <outlet property="activityCollectionContainerView" destination="u8K-at-Gkx" id="482-g6-RVe"/>
+                        <outlet property="chooseView" destination="GUc-7x-7jJ" id="X5A-PB-K7O"/>
+                        <outlet property="manualAddContainerView" destination="iJY-UW-Grx" id="eAU-b2-T50"/>
+                        <outlet property="profileContainerView" destination="qk5-cx-u5k" id="vK8-t1-jZO"/>
                     </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="gAr-U0-wg8" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="5AU-1b-lSq" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1628" y="1298"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="g4o-62-YCR">
-            <objects>
-                <viewController id="ZMK-ej-ioN" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="nP0-FM-xtx">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <viewLayoutGuide key="safeArea" id="gYx-C0-tQb"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="2PP-jT-qb5" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-2581" y="1989"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="Wku-VW-OiX">
-            <objects>
-                <viewController id="AMd-i5-Jpq" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="FYk-Rq-HFo">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <viewLayoutGuide key="safeArea" id="lyc-Uo-eKS"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="2bL-Gw-nas" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-2402" y="2935"/>
+            <point key="canvasLocation" x="-1449.2753623188407" y="17.934782608695652"/>
         </scene>
         <!--Initial Map View Controller-->
         <scene sceneID="kgj-9m-ioV">
@@ -874,7 +696,6 @@
                                             <color key="tintColor" red="0.68235294117647061" green="0.0" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <connections>
                                                 <action selector="closeButtonPressed:" destination="Uq0-XJ-M4B" id="q2l-Iw-AB2"/>
-                                                <segue destination="tE0-sv-0ak" kind="presentation" id="ypa-5v-peG"/>
                                             </connections>
                                         </barButtonItem>
                                     </navigationItem>
@@ -962,7 +783,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="le5-sA-kI4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-810" y="1298"/>
+            <point key="canvasLocation" x="451" y="9"/>
         </scene>
         <!--Start Activity View Controller-->
         <scene sceneID="YcY-uz-tGW">
@@ -993,7 +814,6 @@
                                             <color key="tintColor" red="0.68235294120000001" green="0.0" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <connections>
                                                 <action selector="closeButtonPressed:" destination="Uq0-XJ-M4B" id="Meg-GT-IBT"/>
-                                                <segue destination="tE0-sv-0ak" kind="presentation" id="NUX-b0-Jcf"/>
                                             </connections>
                                         </barButtonItem>
                                     </navigationItem>
@@ -1154,7 +974,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="h81-3C-mAf" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-49.275362318840585" y="1297.8260869565217"/>
+            <point key="canvasLocation" x="1212" y="9"/>
         </scene>
         <!--Activities View Controller-->
         <scene sceneID="qqh-kg-ta8">
@@ -1208,7 +1028,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pgB-Jl-Xhc" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1333" y="-1085"/>
+            <point key="canvasLocation" x="-1846" y="-1084"/>
         </scene>
         <!--New Activity View Controller-->
         <scene sceneID="9uE-fR-MpM">
@@ -1316,7 +1136,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Nb6-VW-tij" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="583" y="-977"/>
+            <point key="canvasLocation" x="-2483" y="-1085"/>
         </scene>
         <!--mainActivityView-->
         <scene sceneID="RfX-AJ-FIU">
@@ -1524,7 +1344,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9aP-hV-BTe" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-768.11594202898561" y="2285.8695652173915"/>
+            <point key="canvasLocation" x="519" y="1049"/>
         </scene>
         <!--statsActivityView-->
         <scene sceneID="8eL-lG-upG">
@@ -1773,7 +1593,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WTl-l2-VqL" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="97" y="2268"/>
+            <point key="canvasLocation" x="1357" y="979"/>
         </scene>
         <!--saveActivityView-->
         <scene sceneID="IFi-Mc-ptB">
@@ -1851,6 +1671,7 @@
                                                         <connections>
                                                             <action selector="recordActivityPressed:" destination="HMM-Ay-f4a" eventType="touchDown" id="Oxg-3q-tx7"/>
                                                             <action selector="recordActivityPressed:" destination="lWa-Ub-qss" eventType="touchUpInside" id="ccy-ot-Ud6"/>
+                                                            <segue destination="Iye-nz-8E5" kind="show" id="ixf-1m-MWY"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>
@@ -1905,7 +1726,228 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KIE-GD-CQb" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="877" y="2268"/>
+            <point key="canvasLocation" x="2138" y="978"/>
+        </scene>
+        <!--Activity Collection View Controller-->
+        <scene sceneID="IuK-UL-L2E">
+            <objects>
+                <viewController id="A9m-Cb-1uW" customClass="ActivityCollectionViewController" customModule="actio" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="6qK-h4-6gN">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="454"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView verifyAmbiguity="off" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsVerticalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kei-uO-JMH">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="454"/>
+                                <subviews>
+                                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="FW6-pe-utx" userLabel="activityCollectionView">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="454"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="4" id="g5W-gu-sBp">
+                                            <size key="itemSize" width="360" height="200"/>
+                                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        </collectionViewFlowLayout>
+                                        <cells>
+                                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="sectionCell" id="9mo-pd-nhU">
+                                                <rect key="frame" x="7" y="0.0" width="400" height="200"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
+                                                    <rect key="frame" x="0.0" y="0.0" width="400" height="200"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <subviews>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cFo-I9-NWU">
+                                                            <rect key="frame" x="8" y="8" width="384" height="184"/>
+                                                            <subviews>
+                                                                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NqI-yd-ai5">
+                                                                    <rect key="frame" x="4" y="0.0" width="380" height="184"/>
+                                                                    <subviews>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hYR-WU-gvy">
+                                                                            <rect key="frame" x="12" y="12" width="167" height="23"/>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="swquare_map" translatesAutoresizingMaskIntoConstraints="NO" id="1Mk-nE-wn6">
+                                                                            <rect key="frame" x="187" y="0.0" width="193" height="184"/>
+                                                                        </imageView>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="April 12, 2018" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iMm-kk-Z7c">
+                                                                            <rect key="frame" x="12" y="34" width="167" height="23"/>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3.31" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cRC-5I-PJJ">
+                                                                            <rect key="frame" x="12" y="66" width="71" height="23"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="23" id="RfZ-4Q-EHU"/>
+                                                                            </constraints>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="distance" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="INa-iy-P2z">
+                                                                            <rect key="frame" x="12" y="87" width="71" height="23"/>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10.02" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vt3-Dz-QGM">
+                                                                            <rect key="frame" x="91" y="65" width="71" height="23"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="width" constant="71" id="862-di-Kwp"/>
+                                                                            </constraints>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="pace" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bVJ-Zl-eQl">
+                                                                            <rect key="frame" x="91" y="87" width="71" height="23"/>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="30:09" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4hh-SK-I6M">
+                                                                            <rect key="frame" x="91" y="110" width="71" height="23"/>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="duration" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iP5-Zx-aJc">
+                                                                            <rect key="frame" x="91" y="132" width="71" height="23"/>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                                            <color key="textColor" red="0.16862745100000001" green="0.1215686275" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                    </subviews>
+                                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                    <constraints>
+                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="leading" secondItem="bVJ-Zl-eQl" secondAttribute="leading" id="1dv-aV-Y41"/>
+                                                                        <constraint firstItem="iMm-kk-Z7c" firstAttribute="leading" secondItem="cRC-5I-PJJ" secondAttribute="leading" id="3JB-GM-5Ty"/>
+                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="trailing" secondItem="bVJ-Zl-eQl" secondAttribute="trailing" id="B93-DR-Qpz"/>
+                                                                        <constraint firstItem="bVJ-Zl-eQl" firstAttribute="leading" secondItem="4hh-SK-I6M" secondAttribute="leading" id="D54-dW-R6W"/>
+                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="leading" secondItem="cRC-5I-PJJ" secondAttribute="trailing" constant="8" symbolic="YES" id="DWc-Ca-whn"/>
+                                                                        <constraint firstItem="iP5-Zx-aJc" firstAttribute="top" secondItem="bVJ-Zl-eQl" secondAttribute="bottom" constant="22" id="DoW-ig-0w4"/>
+                                                                        <constraint firstItem="cRC-5I-PJJ" firstAttribute="leading" secondItem="INa-iy-P2z" secondAttribute="leading" id="EgR-56-7SB"/>
+                                                                        <constraint firstItem="hYR-WU-gvy" firstAttribute="leading" secondItem="iMm-kk-Z7c" secondAttribute="leading" id="FIH-GF-Eiy"/>
+                                                                        <constraint firstAttribute="bottom" secondItem="4hh-SK-I6M" secondAttribute="bottom" constant="51" id="GLo-OG-NdB"/>
+                                                                        <constraint firstItem="iMm-kk-Z7c" firstAttribute="top" secondItem="NqI-yd-ai5" secondAttribute="top" constant="34" id="HRd-fk-Sgl"/>
+                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="top" secondItem="hYR-WU-gvy" secondAttribute="bottom" constant="30" id="ImU-ye-510"/>
+                                                                        <constraint firstItem="INa-iy-P2z" firstAttribute="firstBaseline" secondItem="bVJ-Zl-eQl" secondAttribute="firstBaseline" id="Jmp-VL-UVU"/>
+                                                                        <constraint firstItem="4hh-SK-I6M" firstAttribute="top" secondItem="vt3-Dz-QGM" secondAttribute="bottom" constant="22" id="Jvo-aZ-BOt"/>
+                                                                        <constraint firstAttribute="bottom" secondItem="iP5-Zx-aJc" secondAttribute="bottom" constant="29" id="S4C-NW-OF0"/>
+                                                                        <constraint firstItem="bVJ-Zl-eQl" firstAttribute="trailing" secondItem="4hh-SK-I6M" secondAttribute="trailing" id="ZUK-3K-ROf"/>
+                                                                        <constraint firstItem="1Mk-nE-wn6" firstAttribute="leading" secondItem="iMm-kk-Z7c" secondAttribute="trailing" constant="8" symbolic="YES" id="aKM-Al-Dmc"/>
+                                                                        <constraint firstItem="1Mk-nE-wn6" firstAttribute="leading" secondItem="vt3-Dz-QGM" secondAttribute="trailing" constant="25" id="bN4-Li-BjD"/>
+                                                                        <constraint firstItem="hYR-WU-gvy" firstAttribute="leading" secondItem="NqI-yd-ai5" secondAttribute="leading" constant="12" id="baH-fW-BNJ"/>
+                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="top" secondItem="iMm-kk-Z7c" secondAttribute="bottom" constant="8" symbolic="YES" id="btw-Tv-4VS"/>
+                                                                        <constraint firstItem="INa-iy-P2z" firstAttribute="baseline" secondItem="bVJ-Zl-eQl" secondAttribute="baseline" id="e3p-gr-sj6"/>
+                                                                        <constraint firstAttribute="bottom" secondItem="1Mk-nE-wn6" secondAttribute="bottom" id="lFG-wQ-CaN"/>
+                                                                        <constraint firstItem="1Mk-nE-wn6" firstAttribute="top" secondItem="NqI-yd-ai5" secondAttribute="top" id="lM1-TB-f1I"/>
+                                                                        <constraint firstItem="vt3-Dz-QGM" firstAttribute="leading" secondItem="INa-iy-P2z" secondAttribute="trailing" constant="8" symbolic="YES" id="m0F-Fh-wFx"/>
+                                                                        <constraint firstItem="4hh-SK-I6M" firstAttribute="leading" secondItem="iP5-Zx-aJc" secondAttribute="leading" id="mIa-gH-eca"/>
+                                                                        <constraint firstItem="4hh-SK-I6M" firstAttribute="top" secondItem="bVJ-Zl-eQl" secondAttribute="bottom" id="ngH-EA-OGj"/>
+                                                                        <constraint firstAttribute="bottom" secondItem="cRC-5I-PJJ" secondAttribute="bottom" constant="95" id="ngW-e0-c3M"/>
+                                                                        <constraint firstAttribute="bottom" secondItem="INa-iy-P2z" secondAttribute="bottom" constant="74" id="paT-fa-XR0"/>
+                                                                        <constraint firstItem="hYR-WU-gvy" firstAttribute="top" secondItem="NqI-yd-ai5" secondAttribute="top" constant="12" id="rPo-vf-NRX"/>
+                                                                        <constraint firstItem="1Mk-nE-wn6" firstAttribute="leading" secondItem="hYR-WU-gvy" secondAttribute="trailing" constant="8" symbolic="YES" id="sC8-Za-PzM"/>
+                                                                        <constraint firstItem="INa-iy-P2z" firstAttribute="top" secondItem="iMm-kk-Z7c" secondAttribute="bottom" constant="30" id="umV-yy-6pa"/>
+                                                                        <constraint firstItem="4hh-SK-I6M" firstAttribute="trailing" secondItem="iP5-Zx-aJc" secondAttribute="trailing" id="uqZ-ev-8SI"/>
+                                                                        <constraint firstAttribute="trailing" secondItem="1Mk-nE-wn6" secondAttribute="trailing" id="wOq-d2-bj9"/>
+                                                                        <constraint firstItem="cRC-5I-PJJ" firstAttribute="top" secondItem="iMm-kk-Z7c" secondAttribute="bottom" constant="9" id="y1C-rU-fi9"/>
+                                                                        <constraint firstItem="4hh-SK-I6M" firstAttribute="leading" secondItem="NqI-yd-ai5" secondAttribute="leading" constant="91" id="yUM-bs-wVJ"/>
+                                                                    </constraints>
+                                                                    <userDefinedRuntimeAttributes>
+                                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                            <integer key="value" value="2"/>
+                                                                        </userDefinedRuntimeAttribute>
+                                                                    </userDefinedRuntimeAttributes>
+                                                                </view>
+                                                            </subviews>
+                                                            <color key="backgroundColor" red="0.58823529409999997" green="1" blue="0.86274509799999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="bottom" secondItem="NqI-yd-ai5" secondAttribute="bottom" id="86k-vt-83z"/>
+                                                                <constraint firstItem="NqI-yd-ai5" firstAttribute="leading" secondItem="cFo-I9-NWU" secondAttribute="leading" constant="4" id="E9u-gg-P1d"/>
+                                                                <constraint firstAttribute="trailing" secondItem="NqI-yd-ai5" secondAttribute="trailing" id="OdE-ef-cAA"/>
+                                                                <constraint firstItem="NqI-yd-ai5" firstAttribute="top" secondItem="cFo-I9-NWU" secondAttribute="top" id="sO6-8m-0Pw"/>
+                                                            </constraints>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
+                                                                    <real key="value" value="0.25"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                                <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
+                                                                    <size key="value" width="1" height="1"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </view>
+                                                    </subviews>
+                                                </view>
+                                                <constraints>
+                                                    <constraint firstAttribute="bottomMargin" secondItem="cFo-I9-NWU" secondAttribute="bottom" id="0bz-d0-gGc"/>
+                                                    <constraint firstItem="cFo-I9-NWU" firstAttribute="top" secondItem="9mo-pd-nhU" secondAttribute="topMargin" id="A7Q-fa-EZ5"/>
+                                                    <constraint firstAttribute="trailingMargin" secondItem="cFo-I9-NWU" secondAttribute="trailing" id="GHt-Dj-q3V"/>
+                                                    <constraint firstItem="cFo-I9-NWU" firstAttribute="leading" secondItem="9mo-pd-nhU" secondAttribute="leadingMargin" id="O9b-qw-BTk"/>
+                                                </constraints>
+                                                <size key="customSize" width="400" height="200"/>
+                                            </collectionViewCell>
+                                        </cells>
+                                    </collectionView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="FW6-pe-utx" firstAttribute="bottom" secondItem="4Y8-s9-vFK" secondAttribute="bottom" id="2Ol-F7-RmT"/>
+                                    <constraint firstItem="FW6-pe-utx" firstAttribute="leading" secondItem="kei-uO-JMH" secondAttribute="leading" id="2lQ-PX-ayZ"/>
+                                    <constraint firstItem="FW6-pe-utx" firstAttribute="centerX" secondItem="kei-uO-JMH" secondAttribute="centerX" id="9XA-1K-P11"/>
+                                    <constraint firstItem="FW6-pe-utx" firstAttribute="top" secondItem="4Y8-s9-vFK" secondAttribute="top" id="Cce-bF-Gt0"/>
+                                    <constraint firstAttribute="bottom" secondItem="FW6-pe-utx" secondAttribute="bottom" id="HvN-dc-8q5"/>
+                                    <constraint firstAttribute="trailing" secondItem="FW6-pe-utx" secondAttribute="trailing" id="KKh-OG-cpx"/>
+                                </constraints>
+                                <viewLayoutGuide key="safeArea" id="4Y8-s9-vFK"/>
+                            </scrollView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="kei-uO-JMH" secondAttribute="bottom" id="Rwx-Jl-YyS"/>
+                            <constraint firstAttribute="trailing" secondItem="kei-uO-JMH" secondAttribute="trailing" id="Ue9-8z-3FN"/>
+                            <constraint firstItem="kei-uO-JMH" firstAttribute="leading" secondItem="6qK-h4-6gN" secondAttribute="leading" id="nEL-cS-v3z"/>
+                            <constraint firstItem="kei-uO-JMH" firstAttribute="top" secondItem="6qK-h4-6gN" secondAttribute="top" id="xHf-at-hWM"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="activityCollectionView" destination="FW6-pe-utx" id="PnE-7A-wnT"/>
+                        <outlet property="chooseView" destination="GUc-7x-7jJ" id="Y8w-3v-e75"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="DwN-Nc-ZSe" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-803" y="743"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="5qj-SY-oVP">
+            <objects>
+                <viewController id="IDP-0e-GQV" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="FwI-B0-66i">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="454"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="mnm-4L-okY" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1532" y="743"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="9cS-dA-nhT">
+            <objects>
+                <viewController id="9E8-DX-g5o" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="plS-oZ-N0n">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="454"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="tHL-7q-WR3" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-2288" y="743"/>
         </scene>
     </scenes>
     <resources>
@@ -1927,11 +1969,10 @@
         <image name="swquare_map" width="182" height="175"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="B8J-EK-AmQ"/>
-        <segue reference="ypa-5v-peG"/>
-        <segue reference="CxQ-qp-KFJ"/>
-        <segue reference="Pmv-px-QhH"/>
-        <segue reference="2zd-KK-HrM"/>
+        <segue reference="eCp-ZK-pTW"/>
+        <segue reference="D0k-EN-zs2"/>
+        <segue reference="dUl-3J-noZ"/>
+        <segue reference="BZw-cp-LUj"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.68627450980000004" green="0.0" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
 </document>

--- a/actio/actio/Views/ActivityCollectionViewController.swift
+++ b/actio/actio/Views/ActivityCollectionViewController.swift
@@ -12,10 +12,10 @@ import Firebase
 
 class ActivityCollectionViewController: UIViewController {
     
-
   @IBOutlet weak var activityCollectionView: UICollectionView!
+  
   @IBOutlet weak var chooseView: UIView!
-    var chooseViewActivityType: String!
+  var chooseViewActivityType: String!
   
   @IBOutlet weak var goToTrackRun: UIView!
   
@@ -53,13 +53,11 @@ class ActivityCollectionViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    chooseView.isHidden = true
     activityCollectionView.delegate = self
     activityCollectionView.dataSource = self
   }
   
   override func viewDidDisappear(_ animated: Bool) {
-      chooseView.isHidden = true
   }
     
     

--- a/actio/actio/Views/CoreViewController.swift
+++ b/actio/actio/Views/CoreViewController.swift
@@ -21,12 +21,41 @@ class CoreViewController: UIViewController {
   @IBOutlet weak var profileContainerView: UIView!
   // hidden choose type of activity view
   @IBOutlet weak var chooseView: UIView!
-  
+  @IBOutlet weak var manualAddButton: UIBarButtonItem!
+  @IBOutlet weak var profileButton: UIBarButtonItem!
+  @IBOutlet weak var homeButton: UIBarButtonItem!
   var chooseViewActivityType: String!
-  
-
   @IBOutlet weak var goToTrackRun: UIView!
   
+  @IBAction func showProfileView(sender: UIBarButtonItem) {
+    if (self.profileContainerView.alpha == 0) {
+      UIView.animate(withDuration: 0.5, animations: {
+        self.profileContainerView.alpha = 1
+        self.manualAddContainerView.alpha = 0
+        self.activityCollectionContainerView.alpha = 0
+      })
+    }
+  }
+  
+  @IBAction func showManualAddView(sender: UIBarButtonItem) {
+    if (self.manualAddContainerView.alpha == 0) {
+      UIView.animate(withDuration: 0.5, animations: {
+        self.profileContainerView.alpha = 0
+        self.manualAddContainerView.alpha = 1
+        self.activityCollectionContainerView.alpha = 0
+      })
+    }
+  }
+  
+  @IBAction func showActivityCollectionView(sender: UIBarButtonItem) {
+    if (self.activityCollectionContainerView.alpha == 0) {
+      UIView.animate(withDuration: 0.5, animations: {
+        self.profileContainerView.alpha = 0
+        self.manualAddContainerView.alpha = 0
+        self.activityCollectionContainerView.alpha = 1
+      })
+    }
+  }
   @IBAction func showChooseView(_ sender: AnyObject) {
     chooseView.isHidden = false
     // might add a greyscale to make the background look unavailble.

--- a/actio/actio/Views/CoreViewController.swift
+++ b/actio/actio/Views/CoreViewController.swift
@@ -1,0 +1,82 @@
+//
+//  ActivityCollectionViewController.swift
+//  actio
+//
+//  Created by Alieta Train on 4/29/18.
+//  Copyright © 2018 corvus group. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import Firebase
+
+// container collection container view
+// and profile container view
+class CoreViewController: UIViewController {
+  
+  @IBOutlet weak var activityCollectionView: UICollectionView!
+  // containers
+  @IBOutlet weak var manualAddContainerView: UIView!
+  @IBOutlet weak var activityCollectionContainerView: UIView!
+  @IBOutlet weak var profileContainerView: UIView!
+  // hidden choose type of activity view
+  @IBOutlet weak var chooseView: UIView!
+  
+  var chooseViewActivityType: String!
+  
+
+  @IBOutlet weak var goToTrackRun: UIView!
+  
+  @IBAction func showChooseView(_ sender: AnyObject) {
+    chooseView.isHidden = false
+    // might add a greyscale to make the background look unavailble.
+    // this would also be a large button to unselect the pop up
+    // there is likely a better ios/swift way of doing this so I'm waiting.
+  }
+  
+  @IBAction func hideChooseView(_ sender: AnyObject) {
+    chooseView.isHidden = true
+    // when we leave the screen we need to rehide the pop up prompt
+    // removing it upon return is too slow.
+  }
+  
+  @IBAction func didPressRun() {
+    self.chooseViewActivityType = "Run"
+  }
+  
+  @IBAction func didPressBike() {
+    self.chooseViewActivityType = "Bike"
+  }
+  
+  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+    if let vc = segue.destination as? InitialMapViewController
+    {
+      guard let user = Auth.auth().currentUser else { return }
+      guard let uid = user.uid as? String else { return  }
+      guard let email = user.email as? String else { return }
+      let athlete = Athlete(uid: uid, email: email)
+      vc.activity = Activity(athlete: athlete, type: chooseViewActivityType)
+    }
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    chooseView.isHidden = true
+  }
+  
+  override func viewDidDisappear(_ animated: Bool) {
+    chooseView.isHidden = true
+  }
+  
+  
+  //    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+  //        if segue.identifier == "activitySegue" {
+  //            if let flag = locationManager.gpsFlag, let vc = segue.destination as? InitialMapViewController {
+  //                flag.0 ? (vc.gpsLabel.backgroundColor = UIColor.green) : (vc.gpsLabel.backgroundColor = UIColor.red)
+  //                vc.gpsLabel.text = flag.1
+  //            }
+  //        }
+  //    }
+}
+
+

--- a/actio/actio/Views/SaveActivityViewController.swift
+++ b/actio/actio/Views/SaveActivityViewController.swift
@@ -45,7 +45,7 @@ class SaveActivityViewController: UIViewController {
     data["route"] = ["coordinates": coordinates]
     self.ref.child("activities").childByAutoId().setValue(data)
     // go to activity view
-    //let vc = self.storyboard?.instantiateViewController(withIdentifier: "ActivityCollectionViewController")
-    //self.present(vc!, animated: true, completion: nil)
+//    let vc = self.storyboard?.instantiateViewController(withIdentifier: "ActivityCollectionViewController")
+//    self.present(vc!, animated: true, completion: nil)
   }
 }


### PR DESCRIPTION
- Converting landing view to a core view with containers for profile, activity collection, and manual add. 
- Added segue from 'record' button on activity to activity collection view.  

lacking: 
- method to destroy local activity after recording, so the user can create another entry without crashing the application. 
